### PR TITLE
[SPARK-12071][Doc] Document the behaviour of NA in R

### DIFF
--- a/docs/sparkr.md
+++ b/docs/sparkr.md
@@ -386,6 +386,7 @@ You can inspect the search path in R with [`search()`](https://stat.ethz.ch/R-ma
 ## Upgrading From SparkR 1.5.x to 1.6.x
 
  - Before Spark 1.6.0, the default mode for writes was `append`. It was changed in Spark 1.6.0 to `error` to match the Scala API.
+ - SparkSQL converts `NA` in R to `null`.
 
 ## Upgrading From SparkR 1.6.x to 2.0
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Under Upgrading From SparkR 1.5.x to 1.6.x section added the information, SparkSQL converts `NA` in R to `null`.
## How was this patch tested?

Document update, no tests.
